### PR TITLE
Remove unity3d.com domain

### DIFF
--- a/Hosts.txt
+++ b/Hosts.txt
@@ -3052,7 +3052,6 @@ underclick.ru
 unicume.com
 unilead.com
 unileadnetwork.com
-unity3d.com
 unityads.co.com
 unityads.com
 unityads.unity3d.com

--- a/iPv4Hosts.txt
+++ b/iPv4Hosts.txt
@@ -3052,7 +3052,6 @@
 0.0.0.0 unicume.com
 0.0.0.0 unilead.com
 0.0.0.0 unileadnetwork.com
-0.0.0.0 unity3d.com
 0.0.0.0 unityads.co.com
 0.0.0.0 unityads.com
 0.0.0.0 unityads.unity3d.com


### PR DESCRIPTION
Similar to #19, the `unity3d.com` as a whole should not be blocked since it also serves the Unity engine website.

Example of the legitimate url:
- `https://docs.unity3d.com/Manual/TroubleShootingEditor.html`

The adservers from Unity are already blocked (e.g. `config.unityads.unity3d.com` and many others.)

Thank you for maintaining this list :)