### PR TITLE
maxcdn.bootstrapcdn.com is bootstrap's CDN

### DIFF
--- a/Hosts.txt
+++ b/Hosts.txt
@@ -1925,7 +1925,6 @@ matomy.com
 maudau.com
 mavq.net
 max.i12.de
-maxcdn.bootstrapcdn.com
 maximumcash.com
 maxonclick.com
 mbn.com.ua


### PR DESCRIPTION
maxcdn.bootstrapcdn.com is the content delivery network for bootstrap

see https://getbootstrap.com/docs/4.0/getting-started/introduction/