### PR TITLE
Remove graph.facebook.com from Hosts.txt

### DIFF
--- a/Hosts.txt
+++ b/Hosts.txt
@@ -5943,7 +5943,6 @@ grae.ru
 grafana.appboy.com
 grafstat.ro
 grapeshot.co.uk
-graph.facebook.com
 graphql.api.dailymotion.com
 graphql.groovehq.com
 graphs.amung.us


### PR DESCRIPTION
Remove graph.facebook.com from Hosts.txt as this domain is required for facebook app normal usage