### PR TITLE
Fix wildcard format for AdBlock for iOS by Future Mind

### DIFF
--- a/Miscellaneous(Hosts).txt
+++ b/Miscellaneous(Hosts).txt
@@ -57,7 +57,6 @@
 99centptc.com
 9bux.info
 9icebux.com
-A.W. Surveys
 AAA-mails.com
 Abovebux.com
 Abux1.cn
@@ -641,7 +640,7 @@ ecash-generator.info
 e-clickz.com
 e-dollar.com
 egyptclicks.com
-e-dollar.**
+e-dollar.*
 egyptianclicks.info
 egyptptc.com
 electron-mails.com
@@ -1002,7 +1001,7 @@ LollipopMails.com
 lookingemail.com
 lorikcash.info
 lotionclicks.info
-loveads.**
+loveads.*
 lovebird-mails.com
 Loving-Mail.com
 lowonbux.net

--- a/Miscellaneous(iPv4).txt
+++ b/Miscellaneous(iPv4).txt
@@ -57,7 +57,6 @@
 0.0.0.0 99centptc.com
 0.0.0.0 9bux.info
 0.0.0.0 9icebux.com
-0.0.0.0 A.W. Surveys
 0.0.0.0 AAA-mails.com
 0.0.0.0 Abovebux.com
 0.0.0.0 Abux1.cn
@@ -641,7 +640,7 @@
 0.0.0.0 e-clickz.com
 0.0.0.0 e-dollar.com
 0.0.0.0 egyptclicks.com
-0.0.0.0 e-dollar.**
+0.0.0.0 e-dollar.*
 0.0.0.0 egyptianclicks.info
 0.0.0.0 egyptptc.com
 0.0.0.0 electron-mails.com
@@ -1002,7 +1001,7 @@
 0.0.0.0 lookingemail.com
 0.0.0.0 lorikcash.info
 0.0.0.0 lotionclicks.info
-0.0.0.0 loveads.**
+0.0.0.0 loveads.*
 0.0.0.0 lovebird-mails.com
 0.0.0.0 Loving-Mail.com
 0.0.0.0 lowonbux.net


### PR DESCRIPTION
The list is successfully imported with AdBlock v4.2.1 (current) after these modifications. 