### PR TITLE
Remove www.youtube-nocookie.com

### DIFF
--- a/Hosts.txt
+++ b/Hosts.txt
@@ -13869,7 +13869,6 @@ www.vungle.com
 www.webads.com
 www.woobi.com
 www.youradchoices.com
-www.youtube-nocookie.com
 www.yume.com
 www.za-ads.de
 www.zanox-affiliate.de

--- a/iPv4Hosts.txt
+++ b/iPv4Hosts.txt
@@ -13869,7 +13869,6 @@
 0.0.0.0 www.webads.com
 0.0.0.0 www.woobi.com
 0.0.0.0 www.youradchoices.com
-0.0.0.0 www.youtube-nocookie.com
 0.0.0.0 www.yume.com
 0.0.0.0 www.za-ads.de
 0.0.0.0 www.zanox-affiliate.de


### PR DESCRIPTION
This is actually part of YouTube's [privacy-enhanced mode](https://support.google.com/youtube/answer/171780?hl=en#gbwa:~:text=Turn%20on%20privacy%2Denhanced%20mode).

Fixes #35 