### PR TITLE
removed www.adsbexchange.com due false positive

### DIFF
--- a/Hosts.txt
+++ b/Hosts.txt
@@ -13944,7 +13944,6 @@
 ||www.adfonic.com^$important
 ||www.adgoi.com^$important
 ||www.aditic.com^$important
-||www.adsbexchange.com^$important
 ||www.adtilt.com^$important
 ||www.adxtro.com^$important
 ||www.aerserv.com^$important

--- a/Readme.md
+++ b/Readme.md
@@ -11,7 +11,7 @@ For new users i recommend Adguard Pro, as it allows you to subscribe to a list w
 ___________________________________________________________________________________________________________________________________
 
 Use this link to directly import the list to Adblock by Futuremind: 
-https://raw.githubusercontent.com/BlackJack8/iOSAdblockList/master/Regular%20Hosts.txt
+https://raw.githubusercontent.com/SkyDiscovery/iOSAdblockList/master/Regular%20Hosts.txt
 
 Use this link to subscribe to the list in Adguard Pro:
-https://raw.githubusercontent.com/BlackJack8/iOSAdblockList/master/Hosts.txt
+https://raw.githubusercontent.com/SkyDiscovery/iOSAdblockList/master/Hosts.txt

--- a/Regular Hosts.txt
+++ b/Regular Hosts.txt
@@ -13944,7 +13944,6 @@ www.adcolony.org
 www.adfonic.com
 www.adgoi.com
 www.aditic.com
-www.adsbexchange.com
 www.adtilt.com
 www.adxtro.com
 www.aerserv.com


### PR DESCRIPTION
adsbexchange is „the world’s largest co-op of ADS-B/Mode S/MLAT feeders, and the world’s largest public source of unfiltered flight data. Access to worldwide flight tracking data opens up a whole new world of flight monitoring for hobbyists, researchers, and journalists alike.“